### PR TITLE
Correct Vehicle Store NPCs Not In Their Configured Positions after 1.54 Update...

### DIFF
--- a/mapConfig/storeOwners.sqf
+++ b/mapConfig/storeOwners.sqf
@@ -23,12 +23,12 @@ storeOwnerConfig = compileFinal str
 	["GunStore5", 5, 83, []],
 
 	// Buttons you can disable: "Land", "Armored", "Tanks", "Helicopters", "Boats", "Planes"
-	["VehStore1", 1, 75, []],
+	["VehStore1", -1, 75, []], //Molos Airfield
 	["VehStore2", 6, 45, ["Boats"]],
 	["VehStore3", -1, 329, ["Boats"]],
 	["VehStore4", -1, 225, ["Boats"]],
 	["VehStore5", 1, 69, ["Planes"]],
-	["VehStore6", 4, 282, ["Boats", "Planes"]]
+	["VehStore6", -1, 282, ["Boats", "Planes"]]  //Dump
 ];
 
 // Outfits for store owners

--- a/mission.sqm
+++ b/mission.sqm
@@ -1842,7 +1842,7 @@ class Mission
 				items=1;
 				class Item0
 				{
-					position[]={4565.4165,299.69217,21384.393};
+					position[]={4564.2896,299.49716,21378.879};
 					azimut=350;
 					id=149;
 					side="LOGIC";
@@ -1946,7 +1946,7 @@ class Mission
 				items=1;
 				class Item0
 				{
-					position[]={26712.592,20.398693,24601.9};
+					position[]={26714.498,20.504765,24600.342};
 					azimut=75;
 					id=154;
 					side="LOGIC";
@@ -2051,7 +2051,7 @@ class Mission
 				items=1;
 				class Item0
 				{
-					position[]={5862.0181,225.68094,20106.371};
+					position[]={5857.9956,226.15068,20099.123};
 					azimut=282;
 					id=159;
 					side="LOGIC";


### PR DESCRIPTION
Manually moved NPCs for Vehicle Store 1 and 6 to their configured positions after Arma III update 1.54 broke something and had them out of position. Either that or the NPCs just wanted a change of scenery. Either way, it's fixed! =P