### PR TITLE
Town vehicle persistance tweak...

### DIFF
--- a/server/spawning/vehicleRespawnManager.sqf
+++ b/server/spawning/vehicleRespawnManager.sqf
@@ -209,7 +209,12 @@ while {true} do
 					};
 
 					sleep 0.1;
+					
+					if (fuel _veh < .5) then {
+					
 					deleteVehicle _veh;
+					
+					};
 
 					if (_vehClass isKindOf "Ship_F") then
 					{


### PR DESCRIPTION
Because the cleanup script will "clean-up" town vehicles regardless if they have been saved to the database or not, I have created this tweak. Instead of deleting the original vehicle before recreating it at its origin location, it will evaluate if the vehicle has more than a half-tank of fuel. This is because town vehicles will NOT have a half a tank on-board at spawn. This gives the player a way of saying they want the vehicle to remain, and not be deleted. If it does have more than .5 fuel on-board, it will not delete the vehicle, otherwise it will delete the vehicle. This is the best and most reliable way I have been able to figure out how to selectively override this behavior without flooding the server with town vehicles because they won't clean themselves up.